### PR TITLE
Override _handle_general_error function

### DIFF
--- a/certbot_dns_dynu/dns_dynu.py
+++ b/certbot_dns_dynu/dns_dynu.py
@@ -91,3 +91,8 @@ class _DynuLexiconClient(dns_common_lexicon.LexiconClient):
             return  # Expected errors when zone name guess is wrong
         return super(_DynuLexiconClient, self)._handle_http_error(e, domain_name)
 
+    def _handle_general_error(self, e, domain_name):
+        # Error from https://github.com/AnalogJ/lexicon/blob/master/lexicon/providers/dynu.py#L38
+        if str(e) == "No matching domain found": 
+            return # Expected error when zone name guess is wrong.
+        return super(_DynuLexiconClient, self)._handle_http_error(e, domain_name)


### PR DESCRIPTION
## Issue
Open issue: #2 

lexicon.providers.dynu throws an expected error "No matching domain found" when cycling through domain_name_guesses, but it's not being handled by certbot-dns-dynu. This causes the process to fallback to the parent class _handle_general_error function which causes the whole process to fail while searching for the correct domain_name.

## Proposed fix

Override _handle_general_error to catch the expected error (specifically the text "No matching domain found").

## Results after fix

stdout:

```
Saving debug log to /var/log/letsencrypt/letsencrypt.log
Requesting a certificate for MY.DOMAIN.COM
Waiting 60 seconds for DNS changes to propagate
Successfully received certificate.
Certificate is saved at: /etc/letsencrypt/live/MY.DOMAIN.COM/fullchain.pem
Key is saved at:         /etc/letsencrypt/live/MY.DOMAIN.COM/privkey.pem
This certificate expires on 2022-11-08.
These files will be updated when the certificate renews.

NEXT STEPS:
- The certificate will need to be renewed before it expires. Certbot can automatically renew the certificate in the background, but you may need to take steps to enable that functionality. See https://certbot.org/renewal-setup for instructions.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
If you like Certbot, please consider supporting our work by:
 * Donating to ISRG / Let's Encrypt:   https://letsencrypt.org/donate
 * Donating to EFF:                    https://eff.org/donate-le
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
root@swag:/# openssl x509 -in /etc/letsencrypt/live/MY.DOMAIN.COM/fullchain.pem -noout -text
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            fa:08:e6:02:8a:b0:44:2a:e4:03:00:03:34:fe:56:4d:8d:ea
        Signature Algorithm: sha256WithRSAEncryption
        Issuer: C = US, O = (STAGING) Let's Encrypt, CN = (STAGING) Artificial Apricot R3
        Validity
            Not Before: Aug 10 07:40:35 2022 GMT
            Not After : Nov  8 07:40:34 2022 GMT
        Subject: CN = MY.DOMAIN.COM
        Subject Public Key Info:
            Public Key Algorithm: rsaEncryption
                RSA Public-Key: (4096 bit)
                Modulus:
                    00:aa:20:2a:db:5b:5e:fa:aa:82:bf:32:f0:b1:34:
                    [TRUNCATED]
                Exponent: 65537 (0x10001)
        X509v3 extensions:
            X509v3 Key Usage: critical
                Digital Signature, Key Encipherment
            X509v3 Extended Key Usage:
                TLS Web Server Authentication, TLS Web Client Authentication
            X509v3 Basic Constraints: critical
                CA:FALSE
            X509v3 Subject Key Identifier:
                A7:E2:35:54:AB:7B:BA:2E:42:93:BA:FA:5A:EF:EE:5C:28:0B:B5:80
            X509v3 Authority Key Identifier:
                keyid:DE:72:7A:48:DF:31:C3:A6:50:DF:9F:85:23:DF:57:37:4B:5D:2E:65

            Authority Information Access:
                OCSP - URI:http://stg-r3.o.lencr.org
                CA Issuers - URI:http://stg-r3.i.lencr.org/

            X509v3 Subject Alternative Name:
                DNS: MY.DOMAIN.COM
            X509v3 Certificate Policies:
                Policy: 2.23.140.1.2.1
                Policy: 1.3.6.1.4.1.44947.1.1.1
                  CPS: http://cps.letsencrypt.org

            CT Precertificate SCTs:
                Signed Certificate Timestamp:
                    Version   : v1 (0x0)
                    Log ID    : 16:E8:69:C1:D1:95:EA:D7:C3:F8:97:1A:E3:F0:76:01:
                                F7:8C:E1:B6:9D:31:A8:52:18:B6:83:7F:31:A8:15:08
                    Timestamp : Aug 10 08:40:35.434 2022 GMT
                    Extensions: none
                    Signature : ecdsa-with-SHA256
                                30:45:02:21:00:BB:A0:A8:6F:79:B3:CF:45:E5:5E:6A:
                                [TRUNCATED]3
                Signed Certificate Timestamp:
                    Version   : v1 (0x0)
                    Log ID    : DD:99:34:FC:A5:E7:24:80:C9:56:68:7D:81:34:99:08:
                                49:B2:49:F7:B5:69:D8:C7:BC:AB:3F:5C:C1:F3:6E:64
                    Timestamp : Aug 10 08:40:35.899 2022 GMT
                    Extensions: none
                    Signature : ecdsa-with-SHA256
                                30:45:02:20:38:4B:97:1F:F5:41:8B:EE:40:68:00:92:
                                [TRUNCATED]
    Signature Algorithm: sha256WithRSAEncryption
         72:20:f1:b2:5d:51:c3:b8:3f:0d:f3:8e:c8:71:bb:e0:42:71:
         [TRUNCATED]
```

/var/log/letsencrypt/letsencrypt.log:

```
2022-08-10 02:14:12,387:DEBUG:acme.client:Storing nonce: 0002T21uwLpWX6tlHjlZO8K2EpJLkAc8cAdAafh5h-KDmnk
2022-08-10 02:14:12,387:DEBUG:certbot._internal.error_handler:Calling registered functions
2022-08-10 02:14:12,387:INFO:certbot._internal.auth_handler:Cleaning up challenges
2022-08-10 02:14:12,388:DEBUG:lexicon.providers.dynu:Request: GET /dns with data None
2022-08-10 02:14:12,389:DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): api.dynu.com:443
2022-08-10 02:14:13,093:DEBUG:urllib3.connectionpool:https://api.dynu.com:443 "GET /v2/dns HTTP/1.1" 200 821
2022-08-10 02:14:13,094:DEBUG:lexicon.providers.dynu:Response: <Response [200]>
2022-08-10 02:14:13,095:DEBUG:lexicon.providers.dynu:Request: GET /dns with data None
2022-08-10 02:14:13,096:DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): api.dynu.com:443
2022-08-10 02:14:13,736:DEBUG:urllib3.connectionpool:https://api.dynu.com:443 "GET /v2/dns HTTP/1.1" 200 821
2022-08-10 02:14:13,738:DEBUG:lexicon.providers.dynu:Response: <Response [200]>
2022-08-10 02:14:13,738:DEBUG:lexicon.providers.dynu:Request: GET /dns with data None
2022-08-10 02:14:13,739:DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): api.dynu.com:443
2022-08-10 02:14:14,369:DEBUG:urllib3.connectionpool:https://api.dynu.com:443 "GET /v2/dns HTTP/1.1" 200 821
2022-08-10 02:14:14,371:DEBUG:lexicon.providers.dynu:Response: <Response [200]>
2022-08-10 02:14:14,371:DEBUG:lexicon.providers.dynu:Request: GET /dns/100114705/record with data None
2022-08-10 02:14:14,372:DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): api.dynu.com:443
2022-08-10 02:14:15,038:DEBUG:urllib3.connectionpool:https://api.dynu.com:443 "GET /v2/dns/100114705/record HTTP/1.1" 200 5181
2022-08-10 02:14:15,040:DEBUG:lexicon.providers.dynu:Response: <Response [200]>
2022-08-10 02:14:15,040:DEBUG:lexicon.providers.dynu:list_records: removed 16, total 17
2022-08-10 02:14:15,040:DEBUG:lexicon.providers.dynu:list_records: [{'id': 8737189, 'type': 'TXT', 'name': '_acme-challenge.MY.DOMAIN.COM', 'ttl': 60, 'options': {'enabled': True, 'lastUpdate': '2022-08-10T09:13:31.037', 'raw': {'id': 8737189, 'domainId': 100114705, 'domainName': 'MYDOMAIN.COM', 'nodeName': '_acme-challenge.SUBDOMAIN', 'hostname': '_acme-challenge.MY.DOMAIN.COM', 'recordType': 'TXT', 'ttl': 60, 'state': True, 'content': '_acme-challenge.MY.DOMAIN.COM. 60 IN TXT "EAG6ZrKnzTPiHthEF6T6mjAKv4pUn327tuc6gkDyQtk"', 'updatedOn': '2022-08-10T09:13:31.037', 'textData': 'EAG6ZrKnzTPiHthEF6T6mjAKv4pUn327tuc6gkDyQtk'}, 'TXT': {'data': 'EAG6ZrKnzTPiHthEF6T6mjAKv4pUn327tuc6gkDyQtk'}}, 'content': 'EAG6ZrKnzTPiHthEF6T6mjAKv4pUn327tuc6gkDyQtk'}]
2022-08-10 02:14:15,040:DEBUG:lexicon.providers.dynu:delete_records: [8737189]
2022-08-10 02:14:15,040:DEBUG:lexicon.providers.dynu:Request: DELETE /dns/100114705/record/8737189 with data None
2022-08-10 02:14:15,041:DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): api.dynu.com:443
2022-08-10 02:14:16,305:DEBUG:urllib3.connectionpool:https://api.dynu.com:443 "DELETE /v2/dns/100114705/record/8737189 HTTP/1.1" 200 18
2022-08-10 02:14:16,307:DEBUG:lexicon.providers.dynu:Response: <Response [200]>
2022-08-10 02:14:16,307:DEBUG:lexicon.providers.dynu:delete_record: 8737189
2022-08-10 02:14:16,307:DEBUG:certbot._internal.client:CSR: CSR(file='/etc/letsencrypt/csr/0011_csr-certbot.pem', data=b'-----BEGIN CERTIFICATE REQUEST-----[REDACTED]\n-----END CERTIFICATE REQUEST-----\n', form='pem')
2022-08-10 02:14:16,308:DEBUG:certbot._internal.client:Will poll for certificate issuance until 2022-08-10 02:15:46.308009
2022-08-10 02:14:16,308:DEBUG:acme.client:JWS payload:
b'{\n  "csr": "[REDACTED]"\n}'
2022-08-10 02:14:16,312:DEBUG:acme.client:Sending POST request to https://acme-staging-v02.api.letsencrypt.org/acme/finalize/63979604/3584427224:
{
  "protected": "[REDACTED]",
  "signature": "[REDACTED]",
  "payload": "[REDACTED]"
}
2022-08-10 02:14:16,580:DEBUG:urllib3.connectionpool:https://acme-staging-v02.api.letsencrypt.org:443 "POST /acme/finalize/63979604/3584427224 HTTP/1.1" 200 480
2022-08-10 02:14:16,581:DEBUG:acme.client:Received response:
HTTP 200
Server: nginx
Date: Wed, 10 Aug 2022 09:14:16 GMT
Content-Type: application/json
Content-Length: 480
Connection: keep-alive
Boulder-Requester: 63979604
Cache-Control: public, max-age=0, no-cache
Link: <https://acme-staging-v02.api.letsencrypt.org/directory>;rel="index"
Location: https://acme-staging-v02.api.letsencrypt.org/acme/order/63979604/3584427224
Replay-Nonce: 0002ZcLXBKvqASiUUjkzhd3JYFY_fwluP3MJ2k1-ULU8w1E
X-Frame-Options: DENY
Strict-Transport-Security: max-age=604800

{
  "status": "valid",
  "expires": "2022-08-17T07:15:01Z",
  "identifiers": [
    {
      "type": "dns",
      "value": "MY.DOMAIN.COM"
    }
  ],
  "authorizations": [
    "https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/3292367254"
  ],
  "finalize": "https://acme-staging-v02.api.letsencrypt.org/acme/finalize/63979604/3584427224",
  "certificate": "https://acme-staging-v02.api.letsencrypt.org/acme/cert/[REDACTED]"
}
2022-08-10 02:14:16,581:DEBUG:acme.client:Storing nonce: 0002ZcLXBKvqASiUUjkzhd3JYFY_fwluP3MJ2k1-ULU8w1E
2022-08-10 02:14:17,582:DEBUG:acme.client:JWS payload:
b''
2022-08-10 02:14:17,586:DEBUG:acme.client:Sending POST request to https://acme-staging-v02.api.letsencrypt.org/acme/order/63979604/3584427224:
{
  "protected": "[REDACTED]",
  "signature": "[REDACTED]",
  "payload": ""
}
2022-08-10 02:14:17,611:DEBUG:urllib3.connectionpool:https://acme-staging-v02.api.letsencrypt.org:443 "POST /acme/order/63979604/3584427224 HTTP/1.1" 200 480
2022-08-10 02:14:17,612:DEBUG:acme.client:Received response:
HTTP 200
Server: nginx
Date: Wed, 10 Aug 2022 09:14:17 GMT
Content-Type: application/json
Content-Length: 480
Connection: keep-alive
Cache-Control: public, max-age=0, no-cache
Link: <https://acme-staging-v02.api.letsencrypt.org/directory>;rel="index"
Replay-Nonce: 0001b87RvMxLOu6zO36PvF8M3HLS-uHiPE7YQK2z7jpoCuI
X-Frame-Options: DENY
Strict-Transport-Security: max-age=604800

{
  "status": "valid",
  "expires": "2022-08-17T07:15:01Z",
  "identifiers": [
    {
      "type": "dns",
      "value": "MY.DOMAIN.COM"
    }
  ],
  "authorizations": [
    "https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/3292367254"
  ],
  "finalize": "https://acme-staging-v02.api.letsencrypt.org/acme/finalize/[REDACTED]/[REDACTED]",
  "certificate": "https://acme-staging-v02.api.letsencrypt.org/acme/cert/[REDACTED]"
}
2022-08-10 02:14:17,612:DEBUG:acme.client:Storing nonce: 0001b87RvMxLOu6zO36PvF8M3HLS-uHiPE7YQK2z7jpoCuI
2022-08-10 02:14:17,612:DEBUG:acme.client:JWS payload:
b''
2022-08-10 02:14:17,616:DEBUG:acme.client:Sending POST request to https://acme-staging-v02.api.letsencrypt.org/acme/cert/[REDACTED]:
{
  "protected": "[REDACTED]",
  "signature": "[REDACTED]",
  "payload": ""
}
2022-08-10 02:14:17,663:DEBUG:urllib3.connectionpool:https://acme-staging-v02.api.letsencrypt.org:443 "POST /acme/cert/[REDACTED] HTTP/1.1" 200 6133
2022-08-10 02:14:17,663:DEBUG:acme.client:Received response:
HTTP 200
Server: nginx
Date: Wed, 10 Aug 2022 09:14:17 GMT
Content-Type: application/pem-certificate-chain
Content-Length: 6133
Connection: keep-alive
Cache-Control: public, max-age=0, no-cache
Link: <https://acme-staging-v02.api.letsencrypt.org/directory>;rel="index", <https://acme-staging-v02.api.letsencrypt.org/acme/cert/[REDACTED]/1>;rel="alternate"
Replay-Nonce: 0001Ew4415paRUAsLVQWmiumM6n4gg1Of6ShDIZ3jB1y0vs
X-Frame-Options: DENY
Strict-Transport-Security: max-age=604800

-----BEGIN CERTIFICATE-----
MIIGejCCBWKgAwIBAgITAPpgH+X6vxMLr7bKlIAj3Kr8mDANBgkqhkiG9w0BAQsF
[TRUNCATED]
-----END CERTIFICATE-----

-----BEGIN CERTIFICATE-----
MIIFWzCCA0OgAwIBAgIQTfQrldHumzpMLrM7jRBd1jANBgkqhkiG9w0BAQsFADBm
[TRUNCATED]
-----END CERTIFICATE-----

-----BEGIN CERTIFICATE-----
MIIFVDCCBDygAwIBAgIRAO1dW8lt+99NPs1qSY3Rs8cwDQYJKoZIhvcNAQELBQAw
[TRUNCATED]
-----END CERTIFICATE-----

2022-08-10 02:14:17,664:DEBUG:acme.client:Storing nonce: 0001Ew4415paRUAsLVQWmiumM6n4gg1Of6ShDIZ3jB1y0vs
2022-08-10 02:14:17,664:DEBUG:certbot._internal.storage:Creating directory /etc/letsencrypt/archive/MY.DOMAIN.COM.
2022-08-10 02:14:17,665:DEBUG:certbot._internal.storage:Creating directory /etc/letsencrypt/live/MY.DOMAIN.COM.
2022-08-10 02:14:17,665:DEBUG:certbot._internal.storage:Writing certificate to /etc/letsencrypt/live/MY.DOMAIN.COM/cert.pem.
2022-08-10 02:14:17,665:DEBUG:certbot._internal.storage:Writing private key to /etc/letsencrypt/live/MY.DOMAIN.COM/privkey.pem.
2022-08-10 02:14:17,665:DEBUG:certbot._internal.storage:Writing chain to /etc/letsencrypt/live/MY.DOMAIN.COM/chain.pem.
2022-08-10 02:14:17,665:DEBUG:certbot._internal.storage:Writing full chain to /etc/letsencrypt/live/MY.DOMAIN.COM/fullchain.pem.
2022-08-10 02:14:17,665:DEBUG:certbot._internal.storage:Writing README to /etc/letsencrypt/live/MY.DOMAIN.COM/README.
2022-08-10 02:14:18,087:DEBUG:certbot._internal.plugins.selection:Requested authenticator dns-dynu and installer <certbot._internal.cli.cli_utils._Default object at 0x7f0accb1a700>
2022-08-10 02:14:18,088:DEBUG:certbot._internal.cli:Var server=https://acme-staging-v02.api.letsencrypt.org/directory (set by user).
2022-08-10 02:14:18,088:DEBUG:certbot._internal.cli:Var account={'server'} (set by user).
2022-08-10 02:14:18,088:DEBUG:certbot._internal.cli:Var rsa_key_size=4096 (set by user).
2022-08-10 02:14:18,088:DEBUG:certbot._internal.cli:Var server=https://acme-staging-v02.api.letsencrypt.org/directory (set by user).
2022-08-10 02:14:18,088:DEBUG:certbot._internal.cli:Var authenticator=dns-dynu (set by user).
2022-08-10 02:14:18,089:DEBUG:certbot._internal.cli:Var dns_dynu_propagation_seconds=40 (set by user).
2022-08-10 02:14:18,089:DEBUG:certbot._internal.cli:Var dns_dynu_credentials=/config/dns-conf/dynu.ini (set by user).
2022-08-10 02:14:18,089:DEBUG:certbot._internal.storage:Writing new config /etc/letsencrypt/renewal/MY.DOMAIN.COM.conf.
2022-08-10 02:14:18,091:DEBUG:certbot._internal.display.obj:Notifying user:
Successfully received certificate.
Certificate is saved at: /etc/letsencrypt/live/MY.DOMAIN.COM/fullchain.pem
Key is saved at:         /etc/letsencrypt/live/MY.DOMAIN.COM/privkey.pem
This certificate expires on 2022-11-08.
These files will be updated when the certificate renews.
2022-08-10 02:14:18,091:DEBUG:certbot._internal.display.obj:Notifying user: NEXT STEPS:
2022-08-10 02:14:18,091:DEBUG:certbot._internal.display.obj:Notifying user: - The certificate will need to be renewed before it expires. Certbot can automatically renew the certificate in the background, but you may need to take steps to enable that functionality. See https://certbot.org/renewal-setup for instructions.
2022-08-10 02:14:18,092:DEBUG:certbot._internal.display.obj:Notifying user: If you like Certbot, please consider supporting our work by:
 * Donating to ISRG / Let's Encrypt:   https://letsencrypt.org/donate
 * Donating to EFF:                    https://eff.org/donate-le
```