### PR TITLE
Remove zoap dependencies

### DIFF
--- a/certbot_dns_dynu/dns_dynu.py
+++ b/certbot_dns_dynu/dns_dynu.py
@@ -2,7 +2,6 @@
 
 import logging
 
-import zope.interface
 from certbot import interfaces
 from certbot import errors
 
@@ -14,8 +13,6 @@ from lexicon.providers import dynu
 logger = logging.getLogger(__name__)
 
 
-@zope.interface.implementer(interfaces.IAuthenticator)
-@zope.interface.provider(interfaces.IPluginFactory)
 class Authenticator(dns_common.DNSAuthenticator):
     """DNS Authenticator for Dynu."""
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ install_requires = [
     'dnspython',
     'mock',
     'setuptools',
-    'zope.interface',
     'requests'
 ]
 


### PR DESCRIPTION
Zope was removed in newer versions of certbot, and is no longer supported. dns dynu is thus broken with certbot 2 without removing those dependencies.
See https://github.com/certbot/certbot/pull/9161 for ref

Fixes #4 

Signed-off-by: Aviv Greenberg <avivgr@gmail.com>