### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.md') as f:
 install_requires = [
     'acme>=2.0.0',
     'certbot>=2.0.0',
-    'dns-lexicon==3.11.7',
+    'dns-lexicon>=3.11.7',
     'dnspython',
     'mock',
     'setuptools',


### PR DESCRIPTION
Package works with dns-lexicon versions newer than 3.11.7 (tested with 3.14.1)...